### PR TITLE
Features/normalize contact

### DIFF
--- a/caliopen/base/user/core/contact.py
+++ b/caliopen/base/user/core/contact.py
@@ -6,18 +6,19 @@ import uuid
 from datetime import datetime
 
 from ..store.contact import (Contact as ModelContact,
-                                         IndexedContact,
-                                         Lookup as ModelContactLookup,
-                                         Organization as ModelOrganization,
-                                         PostalAddress as ModelAddress,
-                                         Email as ModelEmail, IM as ModelIM,
-                                         Phone as ModelPhone,
-                                         SocialIdentity as ModelSocialIdentity,
-                                         PublicKey as ModelPublicKey)
+                             IndexedContact,
+                             Lookup as ModelContactLookup,
+                             Organization as ModelOrganization,
+                             PostalAddress as ModelAddress,
+                             Email as ModelEmail, IM as ModelIM,
+                             Phone as ModelPhone,
+                             SocialIdentity as ModelSocialIdentity,
+                             PublicKey as ModelPublicKey)
 
 from caliopen.base.exception import NotFound
 from caliopen.base.core import BaseCore, BaseUserCore
 from caliopen.base.core.mixin import MixinCoreRelation, MixinCoreIndex
+from caliopen.base.helpers import clean_email_address
 
 log = logging.getLogger(__name__)
 
@@ -82,10 +83,15 @@ class Email(BaseContactSubCore):
     _model_class = ModelEmail
     _pkey_name = 'address'
 
+    @property
+    def clean_name(self):
+        clean, _ = clean_email_address(self.name)
+        return clean
 
-class IM(BaseContactSubCore):
+
+class IM(Email):
+    # Inherit from Email as many methods are duplicate
     _model_class = ModelIM
-    _pkey_name = 'address'
 
 
 class Phone(BaseContactSubCore):
@@ -96,6 +102,13 @@ class Phone(BaseContactSubCore):
 class SocialIdentity(BaseContactSubCore):
     _model_class = ModelSocialIdentity
     _pkey_name = 'name'
+
+    @property
+    def clean_name(self):
+        if self.type == 'twitter':
+            return self.name[1:] if self.name.startswith('@') else self.name
+        # XXX processing for others type
+        return self.name
 
 
 class PublicKey(BaseContactSubCore):

--- a/caliopen/base/user/core/contact.py
+++ b/caliopen/base/user/core/contact.py
@@ -19,7 +19,7 @@ from ..store.contact import (Contact as ModelContact,
 from caliopen.base.exception import NotFound
 from caliopen.base.core import BaseCore, BaseUserCore
 from caliopen.base.core.mixin import MixinCoreRelation, MixinCoreIndex
-from caliopen.base.helpers import clean_email_address
+from caliopen.base.user.helpers.normalize import clean_email_address
 
 log = logging.getLogger(__name__)
 
@@ -103,7 +103,8 @@ class Phone(BaseContactSubCore):
     def clean_name(self):
         if self.number.startswith('+'):
             number = phonenumbers.parse(self.number, None)
-            return '+{}{}'.format(number.country_code, number.national_number)
+            phone_format = phonenumbers.PhoneNumberFormat.INTERNATIONAL
+            return phonenumbers.format_number(number, phone_format)
         log.warn('Unable to format phone number {}'.format(self.number))
         return self.number
 
@@ -292,6 +293,21 @@ class Contact(BaseUserCore, MixinCoreRelation, MixinCoreIndex):
         return self._delete_relation('ims', im_addr)
 
     def add_phone(self, phone):
+        if not phone.number.startswith('+'):
+            # try to guess the country code from others phones
+            # and postal addresses
+            others = [phonenumbers.parse(x.number) for x in self.phones]
+            country_codes = list(set([x.country_code for x in others]))
+            if len(country_codes) == 1:
+                code = country_codes[0]
+                country_isos = phonenumbers.COUNTRY_CODE_TO_REGION_CODE[code]
+                if len(country_isos) == 1:
+                    number = phonenumbers.parse(phone.number, country_isos[0])
+                    phone_format = phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                    phone.number = phonenumbers.format_number(number,
+                                                              phone_format)
+                    log.debug('Phone normalized to {}, guess country is {}'.
+                              format(phone.number, country_isos[0]))
         return self._add_relation('phones', phone)
 
     def delete_phone(self, phone_num):

--- a/caliopen/base/user/core/contact.py
+++ b/caliopen/base/user/core/contact.py
@@ -4,6 +4,7 @@
 import logging
 import uuid
 from datetime import datetime
+import phonenumbers
 
 from ..store.contact import (Contact as ModelContact,
                              IndexedContact,
@@ -97,6 +98,14 @@ class IM(Email):
 class Phone(BaseContactSubCore):
     _model_class = ModelPhone
     _pkey_name = 'number'
+
+    @property
+    def clean_name(self):
+        if self.number.startswith('+'):
+            number = phonenumbers.parse(self.number, None)
+            return '+{}{}'.format(number.country_code, number.national_number)
+        log.warn('Unable to format phone number {}'.format(self.number))
+        return self.number
 
 
 class SocialIdentity(BaseContactSubCore):

--- a/caliopen/base/user/helpers/normalize.py
+++ b/caliopen/base/user/helpers/normalize.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Normalization functions for different values."""
+from __future__ import absolute_import, unicode_literals
+
+from email.utils import parseaddr
+
+
+def clean_email_address(addr):
+    """Clean an email address for user resolve."""
+    real_name, email = parseaddr(addr)
+    if not email:
+        raise Exception('Invalid email address %s' % addr)
+    name, domain = email.lower().split('@', 2)
+    if '+' in name:
+        name, ext = name.split('+', 2)
+    # unicode everywhere
+    return (u'%s@%s' % (name, domain), email)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
 requires = [
     'caliopen.base',
+    'phonenumbers',
     ]
 
 extras_require = {


### PR DESCRIPTION
Normalize phone number when creating using external phonenumbers library

Introduce a clean_name property for Email, IM, Phone, SocialIdentity core objects to normalize and be able to compare.